### PR TITLE
Execute the riptide cli as a python module

### DIFF
--- a/riptide_cli/__main__.py
+++ b/riptide_cli/__main__.py
@@ -27,6 +27,7 @@ def print_version():
 
 
 @click.group(
+    name="riptide",
     cls=ClickMainGroup,
     help_headers_color='yellow',
     help_options_color='cyan',
@@ -116,3 +117,7 @@ riptide_cli.command.project.load(cli)
 riptide_cli.command.projects.load(cli)
 for plugin in load_plugins().values():
     plugin.after_load_cli(cli)
+
+
+if __name__ == "__main__":
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     ],
     entry_points='''
         [console_scripts]
-        riptide=riptide_cli.main:cli
+        riptide=riptide_cli.__main__:cli
         riptide_upgrade=riptide_cli.self_updater:update
     ''',
     # Scripts for the shell integration, meant to be sourced.


### PR DESCRIPTION
This PR adjusts the main script of the module, so it can now also be executed as a python module.