### PR TITLE
Replace pkg_resources with importlib

### DIFF
--- a/riptide_cli/__main__.py
+++ b/riptide_cli/__main__.py
@@ -1,6 +1,6 @@
 import os
 
-import pkg_resources
+from importlib.metadata import packages_distributions, version
 import warnings
 
 import click
@@ -28,9 +28,12 @@ from riptide_cli.update_checker import check_for_update
 
 
 def print_version():
-    for pkg in pkg_resources.working_set:
-        if pkg.key.startswith('riptide-'):
-            print(f"{pkg.key:>30}: {pkg.version}")
+    pkgs = packages_distributions()
+    if 'riptide' not in pkgs.keys():
+        print("Couldn't find riptide module in top-level modules:", pkgs.keys())
+        exit(1)
+    for pkg in pkgs['riptide']:
+            print(f"{pkg:>30}: {version(pkg)}")
 
 
 @click.group(

--- a/riptide_cli/self_updater.py
+++ b/riptide_cli/self_updater.py
@@ -1,7 +1,7 @@
 """Riptide self-updater."""
 import os
 
-import pkg_resources
+from importlib.metadata import packages_distributions
 from subprocess import call
 
 from riptide_cli.update_checker import get_version_cache_path
@@ -10,7 +10,7 @@ from riptide_cli.update_checker import get_version_cache_path
 def update():
     print("Updating riptide packages via pip...")
     print()
-    packages = [dist.project_name for dist in pkg_resources.working_set if dist.project_name.startswith('riptide-')]
+    packages = [dist for dist in packages_distributions()['riptide'].values()]
     packages.append('configcrunch')
     call("pip3 install --upgrade " + ' '.join(packages), shell=True)
     print()

--- a/riptide_cli/update_checker.py
+++ b/riptide_cli/update_checker.py
@@ -5,7 +5,7 @@ import time
 from typing import Optional, Dict
 from urllib import request
 
-import pkg_resources
+from importlib.metadata import distribution, packages_distributions, Distribution
 from packaging import version
 
 from riptide.config.files import riptide_config_dir
@@ -22,7 +22,7 @@ def check_for_update() -> Optional[Dict[str, str]]:
         if doc["time"] + 604_800 > time.time():  # 7 days
             cache_is_valid = True
             for pkg_name, cached_ver in doc["versions"].items():
-                dist = pkg_resources.get_distribution(pkg_name)
+                dist = distribution(pkg_name)
                 if dist.version == cached_ver:
                     cache_is_valid = False
                     break
@@ -33,19 +33,19 @@ def check_for_update() -> Optional[Dict[str, str]]:
         pass
 
     versions = {}
-    for pkg in pkg_resources.working_set:
-        if pkg.key.startswith('riptide-'):
-            try:
-                repo_url = _get_repo_url_for_egg(pkg)
-                repo_url = repo_url.replace("github.com", "raw.githubusercontent.com")
-                remote_setuppy = request.urlopen(f"{repo_url}release/setup.py").read().decode('utf-8')
-                rematch = REGEX_VERSION.match(remote_setuppy.splitlines()[0])
-                if rematch:
-                    upstream_version = version.parse(rematch.group(1))
-                    if upstream_version > version.parse(str(pkg.version)):
-                        versions[pkg.key] = str(upstream_version)
-            except Exception:
-                pass
+    for pkg_name in packages_distributions()['riptide']:
+        try:
+            pkg = distribution(pkg_name)
+            repo_url = _get_repo_url_for_egg(pkg)
+            repo_url = repo_url.replace("github.com", "raw.githubusercontent.com")
+            remote_setuppy = request.urlopen(f"{repo_url}release/setup.py").read().decode('utf-8')
+            rematch = REGEX_VERSION.match(remote_setuppy.splitlines()[0])
+            if rematch:
+                upstream_version = version.parse(rematch.group(1))
+                if upstream_version > version.parse(str(pkg.version)):
+                    versions[pkg_name] = str(upstream_version)
+        except Exception:
+            pass
     try:
         with open(cache_path, 'w') as f:
             json.dump({'time': int(time.time()) , 'versions': versions}, f)
@@ -54,14 +54,8 @@ def check_for_update() -> Optional[Dict[str, str]]:
     return versions
 
 
-def _get_repo_url_for_egg(pkg: pkg_resources.Distribution):
-    # There's no real convenient public API for this, but this shouldn't break anytime soon:
-    # noinspection PyProtectedMember
-    lines = pkg._get_metadata(pkg.PKG_INFO)
-    version_lines = filter(lambda l: l.lower().startswith('home-page:'), lines)
-    line = next(iter(version_lines), '')
-    _, _, value = line.partition(':')
-    return value.strip()
+def _get_repo_url_for_egg(pkg: Distribution):
+    return pkg.metadata['Home-page'].strip()
 
 
 def get_version_cache_path():


### PR DESCRIPTION
Since `pkg_resources` has been deprecated in favor of `importlib` this PR replaces the old API with the new one.

As a reference the following migration guides were used:
- [importlib.metadata](https://importlib-metadata.readthedocs.io/en/latest/migration.html)
- [importlib.resources](https://importlib-resources.readthedocs.io/en/latest/migration.html)